### PR TITLE
🔀 :: (ENTRY-26) User 회원탈퇴 API 개발

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,9 @@ dependencies {
 
     // Jwt
     implementation(Dependencies.JWT)
+
+    // Kafka
+    implementation(Dependencies.KAFKA)
 }
 
 tasks.withType<KotlinCompile> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,4 +37,7 @@ object Dependencies {
 
     // Jwt
     const val JWT = "io.jsonwebtoken:jjwt:${DependencyVersions.JWT_VERSION}"
+
+    // Kafka
+    const val KAFKA = "org.springframework.kafka:spring-kafka"
 }

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/domain/UserRole.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/domain/UserRole.kt
@@ -1,6 +1,6 @@
 package hs.kr.equus.user.domain.user.domain
 
-enum class Role {
+enum class UserRole {
     ROOT,
     CONFIRM_APPLICATION,
     USER

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/domain/repository/UserRepository.kt
@@ -8,4 +8,5 @@ interface UserRepository : JpaRepository<User, UUID> {
     fun findByPhoneNumber(phoneNumber: String): Optional<User>
 
     fun existsByPhoneNumber(phoneNumber: String): Boolean
+    fun deleteById(id: UUID?)
 }

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/facade/UserFacade.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/facade/UserFacade.kt
@@ -11,16 +11,12 @@ import java.util.*
 class UserFacade(
     private val userRepository: UserRepository
 ) {
-    fun getCurrentUser(): User? {
+    fun getCurrentUser(): User {
         val userId = SecurityContextHolder.getContext().authentication.name
         return userRepository.findById(UUID.fromString(userId)).orElseThrow { UserNotFoundException }
     }
 
-    fun getUserByPhoneNumber(phoneNumber: String): User? {
+    fun getUserByPhoneNumber(phoneNumber: String): User {
         return userRepository.findByPhoneNumber(phoneNumber).orElseThrow { UserNotFoundException }
-    }
-
-    fun getUserByUserId(id: String): User? {
-        return userRepository.findById(UUID.fromString(id)).orElseThrow { UserNotFoundException }
     }
 }

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/presentation/UserController.kt
@@ -3,10 +3,7 @@ package hs.kr.equus.user.domain.user.presentation
 import hs.kr.equus.user.domain.user.presentation.dto.request.ChangePasswordRequest
 import hs.kr.equus.user.domain.user.presentation.dto.request.UserLoginRequest
 import hs.kr.equus.user.domain.user.presentation.dto.request.UserSignupRequest
-import hs.kr.equus.user.domain.user.service.ChangePasswordService
-import hs.kr.equus.user.domain.user.service.UserLoginService
-import hs.kr.equus.user.domain.user.service.UserSignupService
-import hs.kr.equus.user.domain.user.service.UserTokenRefreshService
+import hs.kr.equus.user.domain.user.service.*
 import hs.kr.equus.user.global.utils.token.dto.TokenResponse
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -18,7 +15,8 @@ class UserController(
     private val userSignupService: UserSignupService,
     private val userLoginService: UserLoginService,
     private val changePasswordService: ChangePasswordService,
-    private val userTokenRefreshService: UserTokenRefreshService
+    private val userTokenRefreshService: UserTokenRefreshService,
+    private val userWithdrawalService: UserWithdrawalService
 ) {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -45,4 +43,7 @@ class UserController(
     @PutMapping("/auth")
     fun tokenRefresh(@RequestHeader("X-Refresh-Token") refreshToken: String): TokenResponse =
         userTokenRefreshService.execute(refreshToken)
+
+    @DeleteMapping
+    fun withdrawal() = userWithdrawalService.execute()
 }

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/service/UserLoginService.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/service/UserLoginService.kt
@@ -1,6 +1,6 @@
 package hs.kr.equus.user.domain.user.service
 
-import hs.kr.equus.user.domain.user.domain.Role
+import hs.kr.equus.user.domain.user.domain.UserRole
 import hs.kr.equus.user.domain.user.domain.repository.UserRepository
 import hs.kr.equus.user.domain.user.exception.PasswordNotValidException
 import hs.kr.equus.user.domain.user.exception.UserNotFoundException
@@ -24,6 +24,6 @@ class UserLoginService(
             throw PasswordNotValidException
         }
 
-        return jwtTokenProvider.generateToken(user.id.toString(), Role.USER.toString())
+        return jwtTokenProvider.generateToken(user.id.toString(), UserRole.USER.toString())
     }
 }

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/service/UserSignupService.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/service/UserSignupService.kt
@@ -2,7 +2,7 @@ package hs.kr.equus.user.domain.user.service
 
 import hs.kr.equus.user.domain.auth.domain.repository.PassInfoRepository
 import hs.kr.equus.user.domain.auth.exception.PassInfoNotFoundException
-import hs.kr.equus.user.domain.user.domain.Role
+import hs.kr.equus.user.domain.user.domain.UserRole
 import hs.kr.equus.user.domain.user.domain.User
 import hs.kr.equus.user.domain.user.domain.repository.UserRepository
 import hs.kr.equus.user.domain.user.exception.UserAlreadyExistsException
@@ -46,7 +46,7 @@ class UserSignupService(
 
         return tokenProvider.generateToken(
             user.phoneNumber,
-            Role.USER.toString()
+            UserRole.USER.toString()
         )
     }
 }

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/service/UserWithdrawalService.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/service/UserWithdrawalService.kt
@@ -1,0 +1,23 @@
+package hs.kr.equus.user.domain.user.service
+
+import hs.kr.equus.user.domain.user.domain.repository.UserRepository
+import hs.kr.equus.user.domain.user.facade.UserFacade
+import hs.kr.equus.user.infrastructure.kafka.configuration.KafkaTopics
+import hs.kr.equus.user.infrastructure.kafka.dto.DeleteUserEventRequest
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserWithdrawalService(
+    private val deleteUserKafkaTemplate: KafkaTemplate<String, DeleteUserEventRequest>,
+    private val userFacade: UserFacade,
+    private val userRepository: UserRepository
+) {
+    @Transactional
+    fun execute(){
+        val user = userFacade.getCurrentUser();
+        userRepository.deleteById(user.id)
+        deleteUserKafkaTemplate.send(KafkaTopics.DELETE_USER, DeleteUserEventRequest(user.id))
+    }
+}

--- a/src/main/kotlin/hs/kr/equus/user/global/security/FilterConfig.kt
+++ b/src/main/kotlin/hs/kr/equus/user/global/security/FilterConfig.kt
@@ -13,13 +13,11 @@ import org.springframework.stereotype.Component
 
 @Component
 class FilterConfig(
-    private val jwtTokenProvider: JwtTokenProvider,
-    private val jwtProperties: JwtProperties,
     private val objectMapper: ObjectMapper
 ) : SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity>() {
     override fun configure(builder: HttpSecurity) {
         builder.addFilterBefore(
-            JwtFilter(jwtProperties, jwtTokenProvider),
+            JwtFilter(),
             UsernamePasswordAuthenticationFilter::class.java
         )
         builder.addFilterBefore(GlobalExceptionFilter(objectMapper), JwtFilter::class.java)

--- a/src/main/kotlin/hs/kr/equus/user/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/hs/kr/equus/user/global/security/SecurityConfig.kt
@@ -14,11 +14,8 @@ import org.springframework.web.cors.CorsUtils
 
 @Configuration
 class SecurityConfig(
-    private val jwtTokenProvider: JwtTokenProvider,
-    private val jwtProperties: JwtProperties,
     private val objectMapper: ObjectMapper
 ) {
-
     @Bean
     protected fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http.csrf()
@@ -47,7 +44,7 @@ class SecurityConfig(
             .authenticated()
 
         http
-            .apply(FilterConfig(jwtTokenProvider, jwtProperties, objectMapper))
+            .apply(FilterConfig(objectMapper))
 
         return http.build()
     }

--- a/src/main/kotlin/hs/kr/equus/user/global/security/jwt/JwtFilter.kt
+++ b/src/main/kotlin/hs/kr/equus/user/global/security/jwt/JwtFilter.kt
@@ -1,25 +1,38 @@
 package hs.kr.equus.user.global.security.jwt
 
+import hs.kr.equus.user.domain.user.domain.UserRole
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.filter.OncePerRequestFilter
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class JwtFilter(
-    private val jwtProperties: JwtProperties,
-    private val jwtTokenProvider: JwtTokenProvider
-) : OncePerRequestFilter() {
+class JwtFilter : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        val token = jwtTokenProvider.resolveToken(request)
+        val userId: String? = request.getHeader("Request-User-Id")
+        val role: UserRole? = request.getHeader("Request-User-Role")?.let { UserRole.valueOf(it) }
+
+        if ((userId == null) || (role == null)) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val authorities = mutableListOf(SimpleGrantedAuthority("ROLE_${role.name}"))
+        val userDetails: UserDetails = User(userId, "", authorities)
+        val authentication: Authentication =
+            UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
 
         SecurityContextHolder.clearContext()
-        token?.let { SecurityContextHolder.getContext().authentication = jwtTokenProvider.authentication(token) }
-
+        SecurityContextHolder.getContext().authentication = authentication
         filterChain.doFilter(request, response)
     }
 }

--- a/src/main/kotlin/hs/kr/equus/user/global/security/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/hs/kr/equus/user/global/security/jwt/JwtTokenProvider.kt
@@ -2,7 +2,7 @@ package hs.kr.equus.user.global.security.jwt
 
 import hs.kr.equus.user.domain.refreshtoken.domain.RefreshToken
 import hs.kr.equus.user.domain.refreshtoken.domain.repository.RefreshTokenRepository
-import hs.kr.equus.user.domain.user.domain.Role
+import hs.kr.equus.user.domain.user.domain.UserRole
 import hs.kr.equus.user.domain.user.domain.repository.UserRepository
 import hs.kr.equus.user.global.exception.ExpiredTokenException
 import hs.kr.equus.user.global.exception.InvalidTokenException
@@ -103,7 +103,7 @@ class JwtTokenProvider(
     private fun getRole(token: String) = getJws(token).body["role"].toString()
 
     private fun getDetails(body: Claims): UserDetails {
-        return if (Role.USER.toString() == body["role"].toString()) {
+        return if (UserRole.USER.toString() == body["role"].toString()) {
             authDetailsService.loadUserByUsername(body.subject)
         } else {
             // 어드민 구현 후 추가 예정

--- a/src/main/kotlin/hs/kr/equus/user/infrastructure/kafka/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/hs/kr/equus/user/infrastructure/kafka/configuration/KafkaConfig.kt
@@ -1,0 +1,33 @@
+package hs.kr.equus.user.infrastructure.kafka.configuration
+
+import hs.kr.equus.user.infrastructure.kafka.dto.DeleteUserEventRequest
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.serializer.JsonSerializer
+
+@Configuration
+class KafkaConfig(
+    private val kafkaProperty: KafkaProperty
+) {
+    @Bean
+    fun deleteUserProducerFactory(): DefaultKafkaProducerFactory<String, DeleteUserEventRequest> {
+        return DefaultKafkaProducerFactory(producerConfig())
+    }
+
+    @Bean
+    fun deleteUserKafkaTemplate(): KafkaTemplate<String, DeleteUserEventRequest> {
+        return KafkaTemplate(deleteUserProducerFactory())
+    }
+
+    private fun producerConfig(): MutableMap<String, Any> {
+        val configs: MutableMap<String, Any> = HashMap<String, Any>()
+        configs[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = kafkaProperty.serverAddress
+        configs[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+        configs[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JsonSerializer::class.java
+        return configs
+    }
+}

--- a/src/main/kotlin/hs/kr/equus/user/infrastructure/kafka/configuration/KafkaProperty.kt
+++ b/src/main/kotlin/hs/kr/equus/user/infrastructure/kafka/configuration/KafkaProperty.kt
@@ -1,0 +1,10 @@
+package hs.kr.equus.user.infrastructure.kafka.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties("kafka")
+class KafkaProperty (
+    val serverAddress: String
+)

--- a/src/main/kotlin/hs/kr/equus/user/infrastructure/kafka/configuration/KafkaTopics.kt
+++ b/src/main/kotlin/hs/kr/equus/user/infrastructure/kafka/configuration/KafkaTopics.kt
@@ -1,0 +1,7 @@
+package hs.kr.equus.user.infrastructure.kafka.configuration
+
+class KafkaTopics {
+    companion object {
+        const val DELETE_USER = "delete-user"
+    }
+}

--- a/src/main/kotlin/hs/kr/equus/user/infrastructure/kafka/dto/DeleteUserEventRequest.kt
+++ b/src/main/kotlin/hs/kr/equus/user/infrastructure/kafka/dto/DeleteUserEventRequest.kt
@@ -1,0 +1,7 @@
+package hs.kr.equus.user.infrastructure.kafka.dto
+
+import java.util.UUID
+
+data class DeleteUserEventRequest(
+    val userId: UUID?
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,6 @@ auth:
         refreshExp: ${JWT_REFRESH_EXP:3600}
         header: ${JWT_HEADER:Authorization}
         prefix: ${JWT_PREFIX:Bearer}
+
+kafka:
+    serverAddress: ${KAFKA_SERVER_ADDRESS:localhost:9092}


### PR DESCRIPTION
close #ENTRY-26

회원탈퇴 시 Kafka delete-user 토픽에 메시지를 발행합니다.

다른 서비스에서 해당 토픽에 있는 메시지를 consume 하여 status, entryinfo를 삭제하는 로직을 수행하도록 로직을 구성해야 합니다.

그리고 Topic 에 대해서 Replica, Partition 의 개수를 실제 환경에서 Kafka 클러스터 구축을 한 뒤 더 자세히 설정할 계획입니다.

