### PR TITLE
🔀 :: (entry-237) user cache설정 fallback method 작성

### DIFF
--- a/src/main/kotlin/hs/kr/equus/user/domain/refreshtoken/domain/RefreshToken.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/refreshtoken/domain/RefreshToken.kt
@@ -1,9 +1,9 @@
 package hs.kr.equus.user.domain.refreshtoken.domain
 
+import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
 import org.springframework.data.redis.core.index.Indexed
-import javax.persistence.Id
 
 @RedisHash
 class RefreshToken(

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/domain/User.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/domain/User.kt
@@ -38,4 +38,16 @@ class User(
     fun changeReceiptCode(receiptCode: Long) {
         this.receiptCode = receiptCode
     }
+
+    fun mapper(): UserCache {
+        return UserCache(
+            id = id,
+            phoneNumber = phoneNumber,
+            name = name,
+            isParent = isParent,
+            receiptCode = receiptCode,
+            role = role,
+            ttl = 60*10
+        )
+    }
 }

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/domain/User.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/domain/User.kt
@@ -39,7 +39,7 @@ class User(
         this.receiptCode = receiptCode
     }
 
-    fun mapper(): UserCache {
+    fun toUserCache(): UserCache {
         return UserCache(
             id = id,
             phoneNumber = phoneNumber,

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/domain/UserCache.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/domain/UserCache.kt
@@ -1,0 +1,19 @@
+package hs.kr.equus.user.domain.user.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+import java.util.*
+
+@RedisHash(value = "user_cache")
+data class UserCache (
+    @Id
+    val id: UUID?,
+    val phoneNumber: String,
+    val name: String,
+    val isParent: Boolean,
+    val receiptCode: Long?,
+    val role: UserRole,
+    @TimeToLive
+    val ttl: Long
+)

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/domain/repository/UserCacheRepository.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/domain/repository/UserCacheRepository.kt
@@ -1,0 +1,8 @@
+package hs.kr.equus.user.domain.user.domain.repository
+
+import hs.kr.equus.user.domain.user.domain.UserCache
+import org.springframework.data.repository.CrudRepository
+import java.util.UUID
+
+interface UserCacheRepository : CrudRepository<UserCache, UUID> {
+}

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/service/QueryUserByUUIDService.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/service/QueryUserByUUIDService.kt
@@ -18,7 +18,7 @@ class QueryUserByUUIDService(
     fun execute(userId: UUID): InternalUserResponse {
         val user = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException
         if (!userCacheRepository.existsById(userId)) {
-            userCacheRepository.save(user.mapper())
+            userCacheRepository.save(user.toUserCache())
         }
         return InternalUserResponse(
             id = user.id!!,

--- a/src/main/kotlin/hs/kr/equus/user/domain/user/service/QueryUserByUUIDService.kt
+++ b/src/main/kotlin/hs/kr/equus/user/domain/user/service/QueryUserByUUIDService.kt
@@ -1,5 +1,6 @@
 package hs.kr.equus.user.domain.user.service
 
+import hs.kr.equus.user.domain.user.domain.repository.UserCacheRepository
 import hs.kr.equus.user.domain.user.domain.repository.UserRepository
 import hs.kr.equus.user.domain.user.exception.UserNotFoundException
 import hs.kr.equus.user.domain.user.presentation.dto.response.InternalUserResponse
@@ -10,11 +11,15 @@ import java.util.UUID
 
 @Service
 class QueryUserByUUIDService(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val userCacheRepository: UserCacheRepository
 ) {
     @Transactional(readOnly = true)
     fun execute(userId: UUID): InternalUserResponse {
         val user = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException
+        if (!userCacheRepository.existsById(userId)) {
+            userCacheRepository.save(user.mapper())
+        }
         return InternalUserResponse(
             id = user.id!!,
             phoneNumber = user.phoneNumber,

--- a/src/main/kotlin/hs/kr/equus/user/global/config/RedisConfig.kt
+++ b/src/main/kotlin/hs/kr/equus/user/global/config/RedisConfig.kt
@@ -1,0 +1,36 @@
+package hs.kr.equus.user.global.config
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig {
+    @Bean
+    fun redisTemplate(connectionFactory: RedisConnectionFactory, objectMapper: ObjectMapper): RedisTemplate<String, Any> {
+        val template = RedisTemplate<String, Any>()
+        template.setConnectionFactory(connectionFactory)
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = Jackson2JsonRedisSerializer(Any::class.java).apply {
+            setObjectMapper(objectMapper)
+        }
+        return template
+    }
+
+    @Bean
+    fun objectMapper(): ObjectMapper {
+        val mapper = ObjectMapper()
+        mapper.registerModule(KotlinModule())
+        mapper.activateDefaultTyping(LaissezFaireSubTypeValidator(), ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY)
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        return mapper
+    }
+}


### PR DESCRIPTION
close #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 사용자 캐싱을 위한 `UserCache` 데이터 클래스 추가.
	- 사용자 정보를 Redis에 저장하는 `UserCacheRepository` 인터페이스 추가.
	- `QueryUserByUUIDService`에서 캐시 기능 통합, 사용자 조회 시 캐시 확인 및 저장 로직 추가.
	- `User` 클래스에 `mapper()` 및 `toUserCache()` 메서드 추가로 사용자 정보를 `UserCache`로 변환.

- **구성**
	- Redis 설정을 위한 `RedisConfig` 클래스 추가, RedisTemplate 및 ObjectMapper 빈 정의.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->